### PR TITLE
BUG: updating failing tests after config change

### DIFF
--- a/tests/allocations/allocations.spec.js
+++ b/tests/allocations/allocations.spec.js
@@ -15,7 +15,7 @@ test.describe('Allocation Page Tests', () => {
     test('Request New Allocation button is clickable and opens new tab', async ({ page }) => {
 
         const requestNewAllocationButton = page.getByRole('link', { name: 'Request New Allocation' })
-        
+
         expect(await requestNewAllocationButton.getAttribute('href')).toEqual('https://submit-tacc.xras.org/')
 
         const requestNewAllocationPagePromise = page.waitForEvent('popup');
@@ -26,12 +26,12 @@ test.describe('Allocation Page Tests', () => {
     })
 
     test('View Team modal open and close flow', async ({ page }) => {
-        await page.getByRole('button', { name: 'View Team' }).nth(1).click();
+        await page.getByRole('button', { name: 'View Team' }).nth(0).click();
         await expect(page.locator('.modal-dialog')).toBeVisible();
         await expect(page.getByRole('tab', { name: 'View Team' })).toBeVisible();
         await page.getByRole('dialog').getByRole('button', { name: 'Close' }).click();
         await expect(page.locator('.modal-dialog')).not.toBeVisible();
-        
+
     })
 
     test('Correct sidebar items displayed and can be navigated between', async ({ page }) => {
@@ -49,5 +49,5 @@ test.describe('Allocation Page Tests', () => {
         expect(headingValueExpired).toBe('Allocations/Expired');
 
     })
-    
+
 })

--- a/tests/data-files/data-files-my-data.spec.js
+++ b/tests/data-files/data-files-my-data.spec.js
@@ -3,18 +3,6 @@ import { test } from '../../fixtures/baseFixture'
 
 //note: these tests are for all 3 types of my data available on dev.cep
 //TODO: get these to pick which one to use based on what portal we're testing on
-test('test navigation to my data corral', async ({ page, portal, environment }) => {
-
-  const url = `https://${environment === 'prod' ? '' : `${environment}.`}${portal}.tacc.utexas.edu`;
-  await page.goto(url);
-  await page.locator('#navbarDropdown').click();
-  await page.getByRole('link', { name: 'Dashboard' }).click();
-  await page.getByRole('link', { name: 'Data Files' }).click();
-
-  const heading = page.getByRole('heading', {level: 2});
-  await expect(heading).toHaveText("My Data (Corral)");
-});
-
 test('test navigation to my data work', async ({ page, portal, environment }) => {
 
   const url = `https://${environment === 'prod' ? '' : `${environment}.`}${portal}.tacc.utexas.edu`;
@@ -22,10 +10,22 @@ test('test navigation to my data work', async ({ page, portal, environment }) =>
   await page.locator('#navbarDropdown').click();
   await page.getByRole('link', { name: 'Dashboard' }).click();
   await page.getByRole('link', { name: 'Data Files' }).click();
-  await page.getByRole('link', { name: "My Data (Work)"}).click();
 
   const heading = page.getByRole('heading', {level: 2});
   await expect(heading).toHaveText("My Data (Work)");
+});
+
+test('test navigation to my data scratch', async ({ page, portal, environment }) => {
+
+  const url = `https://${environment === 'prod' ? '' : `${environment}.`}${portal}.tacc.utexas.edu`;
+  await page.goto(url);
+  await page.locator('#navbarDropdown').click();
+  await page.getByRole('link', { name: 'Dashboard' }).click();
+  await page.getByRole('link', { name: 'Data Files' }).click();
+  await page.getByRole('link', { name: "My Data (Scratch)"}).click();
+
+  const heading = page.getByRole('heading', {level: 2});
+  await expect(heading).toHaveText("My Data (Scratch)");
 });
 
 test('test navigation to my data frontera', async ({ page, portal, environment }) => {

--- a/tests/history/history.spec.js
+++ b/tests/history/history.spec.js
@@ -28,12 +28,12 @@ test.describe('History Page Navigation Tests', () => {
     })
 
     test('Jobv2 tab is displayed and redirects correctly', async ({ page, portal, environment }) => {
-        await expect(page.getByRole('link', { name: 'Pre-April 2023' })).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Pre-June 2023' })).toBeVisible();
 
-        await page.getByRole('link', { name: 'Pre-April 2023' }).click();
+        await page.getByRole('link', { name: 'Pre-June 2023' }).click();
 
         const heading = page.getByRole('heading', { level: 2 })
-        await expect(heading).toHaveText('History / Pre-April 2023')
+        await expect(heading).toHaveText('History / Pre-June 2023')
 
         const url = `https://${environment === 'prod' ? '' : `${environment}.`}${portal}.tacc.utexas.edu`;
         expect(page.url()).toBe(`${url}/workbench/history/jobsv2`)

--- a/tests/unauthorized-user/unauthorized-user.spec.js
+++ b/tests/unauthorized-user/unauthorized-user.spec.js
@@ -3,11 +3,11 @@ import { test } from '../../fixtures/baseFixture'
 
 
 test('test topnav navigation to public data page', async ({ page, portal, environment }) => {
-    
+
     const url = `https://${environment === 'prod' ? '' : `${environment}.`}${portal}.tacc.utexas.edu`;
     await page.goto(url);
     await page.getByRole('link', { name: 'Public Data' }).click();
-    
+
     const heading = page.getByRole('heading', {level: 2});
     await expect(heading).toHaveText('Public Data');
   });
@@ -16,10 +16,10 @@ test('test topnav navigation to public data page', async ({ page, portal, enviro
     const url = `https://${environment === 'prod' ? '' : `${environment}.`}${portal}.tacc.utexas.edu/workbench/dashboard`;
     await page.goto(url);
 
-    await page.waitForURL("https://portals.develop.tapis.io/**")
+    await page.waitForURL("https://portals.tapis.io/**")
 
-    const heading = page.getByRole('heading', {level: 1});
-    await expect(heading).toHaveText('Log In');
+    const heading = page.getByRole('heading', {level: 2});
+    await expect(heading).toHaveText('Tapis Login - Tenant portals');
   })
 
 


### PR DESCRIPTION
After the config changes, these tests were still failing due to differences between the two portals and users.  This should clear up those errors.