### PR TITLE
task/WMAQA-38 - Refactor tests to be portal agnostic

### DIFF
--- a/tests/allocations/allocations.spec.js
+++ b/tests/allocations/allocations.spec.js
@@ -12,7 +12,7 @@ test.describe('Allocation Page Tests', () => {
         await page.goto(baseURL);
         await page.locator('#navbarDropdown').click();
         await page.getByRole('link', { name: 'My Dashboard' }).click();
-        await page.getByRole('link', { name: 'Allocations' }).click();
+        await page.locator('#react-root').getByRole('link', { name: 'Allocations' }).click();
     })
 
     test('Request New Allocation button is clickable and opens new tab', async ({ page }) => {

--- a/tests/allocations/allocations.spec.js
+++ b/tests/allocations/allocations.spec.js
@@ -1,4 +1,4 @@
-import { test } from '../../fixtures/baseFixture.js'
+import { test } from '../../fixtures/baseFixture';
 import { expect, base } from '@playwright/test';
 import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
 

--- a/tests/allocations/allocations.spec.js
+++ b/tests/allocations/allocations.spec.js
@@ -1,8 +1,12 @@
-import { test } from '../../fixtures/baseFixture'
+import { test } from '../../fixtures/baseFixture.js'
 import { expect, base } from '@playwright/test';
+import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
+
+const hideAllocations = WORKBENCH_SETTINGS['hideAllocations'];
 
 
 test.describe('Allocation Page Tests', () => {
+    test.skip(hideAllocations === true, 'Allocations hidden on portal, test skipped');
 
     test.beforeEach(async ({ page, portal, environment, baseURL }) => {
         await page.goto(baseURL);

--- a/tests/applications/applications.spec.js
+++ b/tests/applications/applications.spec.js
@@ -4,7 +4,6 @@ import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
 
 const hideApps = WORKBENCH_SETTINGS['hideApps'];
 
-
 test('test navigation to application page', async ({ page, portal, environment, baseURL }) => {
   test.skip(hideApps === true, 'Apps hidden on portal, test skipped');
   await page.goto(baseURL);

--- a/tests/applications/applications.spec.js
+++ b/tests/applications/applications.spec.js
@@ -1,5 +1,5 @@
 import { expect, base } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture.js';
+import { test } from '../../fixtures/baseFixture';
 import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
 
 const hideApps = WORKBENCH_SETTINGS['hideApps'];

--- a/tests/applications/applications.spec.js
+++ b/tests/applications/applications.spec.js
@@ -1,14 +1,18 @@
 import { expect, base } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture';
+import { test } from '../../fixtures/baseFixture.js';
+import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
+
+const hideApps = WORKBENCH_SETTINGS['hideApps'];
+
 
 test('test navigation to application page', async ({ page, portal, environment, baseURL }) => {
+  test.skip(hideApps === true, 'Apps hidden on portal, test skipped');
+  await page.goto(baseURL);
+  await page.locator('#navbarDropdown').click();
+  await page.getByRole('link', { name: 'Dashboard' }).click();
+  await page.getByRole('link', { name: 'Applications', exact: true }).click();
 
-    await page.goto(baseURL);
-    await page.locator('#navbarDropdown').click();
-    await page.getByRole('link', { name: 'Dashboard' }).click();
-    await page.getByRole('link', { name: 'Applications', exact: true }).click();
-
-    const heading = page.getByRole('heading', {level: 2});
-    await expect(heading).toHaveText('Applications');
-    
-  });
+  const heading = page.getByRole('heading', {level: 2});
+  await expect(heading).toHaveText('Applications');
+  
+});

--- a/tests/data-files/data-files-add.spec.js
+++ b/tests/data-files/data-files-add.spec.js
@@ -1,5 +1,5 @@
 import { expect, base, Page } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture.js';
+import { test } from '../../fixtures/baseFixture';
 import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
 
 const hideDataFiles = WORKBENCH_SETTINGS['hideDataFiles'];

--- a/tests/data-files/data-files-add.spec.js
+++ b/tests/data-files/data-files-add.spec.js
@@ -1,11 +1,7 @@
-import { expect, base, Page } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture';
 import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
-
-const hideDataFiles = WORKBENCH_SETTINGS['hideDataFiles'];
-import { base, Page } from '@playwright/test';
-import { test, expect } from '../../fixtures/fileOperationsFixture'
+import { expect, test } from '../../fixtures/fileOperationsFixture'
  
+const hideDataFiles = WORKBENCH_SETTINGS['hideDataFiles'];
 
 test.describe('test Add button', async () => {
   test.skip(hideDataFiles === true, 'Data Files hidden on portal, test skipped');

--- a/tests/data-files/data-files-add.spec.js
+++ b/tests/data-files/data-files-add.spec.js
@@ -1,8 +1,11 @@
 import { expect, base, Page } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture'
- 
+import { test } from '../../fixtures/baseFixture.js';
+import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
+
+const hideDataFiles = WORKBENCH_SETTINGS['hideDataFiles'];
 
 test.describe('test Add button', async () => {
+  test.skip(hideDataFiles === true, 'Data Files hidden on portal, test skipped');
 
   test.describe.configure({ mode: 'serial' });
 

--- a/tests/data-files/data-files-search.spec.js
+++ b/tests/data-files/data-files-search.spec.js
@@ -1,5 +1,5 @@
 import { expect, base } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture.js';
+import { test } from '../../fixtures/baseFixture';
 import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
  
 const hideDataFiles = WORKBENCH_SETTINGS['hideDataFiles'];

--- a/tests/data-files/data-files-search.spec.js
+++ b/tests/data-files/data-files-search.spec.js
@@ -1,9 +1,12 @@
 import { expect, base } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture'
+import { test } from '../../fixtures/baseFixture.js';
+import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
  
+const hideDataFiles = WORKBENCH_SETTINGS['hideDataFiles'];
 
 test.describe('Data Files Search Tests', () => {
-    
+    test.skip(hideDataFiles === true, 'Data Files hidden on portal, test skipped');
+
     test.beforeEach(async ({ page, portal, environment, baseURL }) => {
         await page.goto(baseURL);
         await page.locator('#navbarDropdown').click();

--- a/tests/data-files/data-files-systems.spec.js
+++ b/tests/data-files/data-files-systems.spec.js
@@ -1,5 +1,5 @@
 import { expect, base } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture.js';
+import { test } from '../../fixtures/baseFixture';
 import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
 import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json';
 

--- a/tests/data-files/data-files-systems.spec.js
+++ b/tests/data-files/data-files-systems.spec.js
@@ -1,12 +1,14 @@
 import { expect, base } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture'
- 
-import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json'
+import { test } from '../../fixtures/baseFixture.js';
+import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
+import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json';
 
-const portalStorageSystems = PORTAL_DATAFILES_STORAGE_SYSTEMS
+const portalStorageSystems = PORTAL_DATAFILES_STORAGE_SYSTEMS;
+const hideDataFiles = WORKBENCH_SETTINGS['hideDataFiles'];
 
 test.describe('Data Files Navigation Tests', () => {
-  
+  test.skip(hideDataFiles === true, 'Data Files hidden on portal, test skipped');
+
   test.beforeEach(async ({ page, baseURL }) => {
     await page.goto(baseURL);
     await page.locator('#navbarDropdown').click();

--- a/tests/history/history.spec.js
+++ b/tests/history/history.spec.js
@@ -1,4 +1,4 @@
-import { test } from '../../fixtures/baseFixture.js'
+import { test } from '../../fixtures/baseFixture'
 import { expect, base } from '@playwright/test';
 import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
  

--- a/tests/history/history.spec.js
+++ b/tests/history/history.spec.js
@@ -1,5 +1,8 @@
-import { test } from '../../fixtures/baseFixture'
+import { test } from '../../fixtures/baseFixture.js'
 import { expect, base } from '@playwright/test';
+import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
+ 
+const jobsv2Title = WORKBENCH_SETTINGS['jobsv2Title'];
  
 
 
@@ -28,12 +31,12 @@ test.describe('History Page Navigation Tests', () => {
     })
 
     test('Jobv2 tab is displayed and redirects correctly', async ({ page, portal, environment, baseURL }) => {
-        await expect(page.getByRole('link', { name: 'Pre-June 2023' })).toBeVisible();
+        await expect(page.getByRole('link', { name: jobsv2Title })).toBeVisible();
 
-        await page.getByRole('link', { name: 'Pre-June 2023' }).click();
+        await page.getByRole('link', { name: jobsv2Title }).click();
 
         const heading = page.getByRole('heading', { level: 2 })
-        await expect(heading).toHaveText('History / Pre-June 2023')
+        await expect(heading).toHaveText('History / ' + jobsv2Title)
 
         const url = baseURL
         expect(page.url()).toBe(`${url}/workbench/history/jobsv2`)

--- a/tests/publicData/publicData.spec.js
+++ b/tests/publicData/publicData.spec.js
@@ -1,5 +1,5 @@
 import { expect, base } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture.js';
+import { test } from '../../fixtures/baseFixture';
 import { NGINX_SERVER_NAME } from '../../settings/custom_portal_settings.json';
 
 test.describe('Public Data Tests', () => {

--- a/tests/publicData/publicData.spec.js
+++ b/tests/publicData/publicData.spec.js
@@ -2,15 +2,24 @@ import { expect, base } from '@playwright/test';
 import { test } from '../../fixtures/baseFixture';
 import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json';
 
-test.describe('Public Data Tests', () => {
-  test.skip(PORTAL_DATAFILES_STORAGE_SYSTEMS != 'Public Data', 'Public Data not on portal, test skipped');
+let publicDataEntry = false;
+for (const entry of PORTAL_DATAFILES_STORAGE_SYSTEMS) {
+  if (entry.name === "Public Data") {
+    publicDataEntry = true;
+    break;
+  }
+}
+
+test.describe('Public Data Tests', async () => {
+  
+  test.skip(publicDataEntry === false, 'Public Data not on portal, test skipped');
 
   test.beforeEach(async ({ page, portal, environment, baseURL }) => {
     await page.goto(baseURL);
   })
     
   test('test topnav navigation to public data page', async ({ page, portal, environment, baseURL }) => {
-      
+
       await page.getByRole('link', { name: 'Public Data' }).click();
       
       const heading = page.getByRole('heading', {level: 2});

--- a/tests/publicData/publicData.spec.js
+++ b/tests/publicData/publicData.spec.js
@@ -1,10 +1,10 @@
 import { expect, base } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture'
- 
-
+import { test } from '../../fixtures/baseFixture.js';
+import { NGINX_SERVER_NAME } from '../../settings/custom_portal_settings.json';
 
 test.describe('Public Data Tests', () => {
-  
+  test.skip(NGINX_SERVER_NAME != 'cep.tacc.utexas.edu', 'Public Data not on portal, test skipped');
+
   test.beforeEach(async ({ page, portal, environment, baseURL }) => {
     await page.goto(baseURL);
   })

--- a/tests/publicData/publicData.spec.js
+++ b/tests/publicData/publicData.spec.js
@@ -4,7 +4,7 @@ import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_s
 
 let publicDataEntry = false;
 for (const entry of PORTAL_DATAFILES_STORAGE_SYSTEMS) {
-  if (entry.name === "Public Data") {
+  if (entry.scheme === "public") {
     publicDataEntry = true;
     break;
   }

--- a/tests/setup/auth.setup.js
+++ b/tests/setup/auth.setup.js
@@ -1,4 +1,4 @@
-import { test as setup } from '../../fixtures/baseFixture.js'
+import { test as setup } from '../../fixtures/baseFixture'
 import { SYSTEM_MONITOR_DISPLAY_LIST, PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json'
 
 const authFile = 'playwright/.auth/user.json';

--- a/tests/setup/auth.setup.js
+++ b/tests/setup/auth.setup.js
@@ -1,4 +1,4 @@
-import { test as setup } from '../../fixtures/baseFixture'
+import { test as setup } from '../../fixtures/baseFixture.js'
 import { SYSTEM_MONITOR_DISPLAY_LIST, PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json'
 
 const authFile = 'playwright/.auth/user.json';

--- a/tests/system-status/system-status.spec.js
+++ b/tests/system-status/system-status.spec.js
@@ -13,9 +13,9 @@ test.describe('System Status page tests', () => {
 
     test('All systems for portal displayed in sidebar and can be navigated between', async ({ page }) => {
         for (const system of SYSTEM_MONITOR_DISPLAY_LIST) {
-            await expect(page.getByRole('link', { name: system })).toBeVisible();
+            await expect(page.getByRole('link', { name: system, exact: true })).toBeVisible();
 
-            await page.getByRole('link', { name: system }).click();
+            await page.getByRole('link', { name: system, exact: true }).click();
 
             const headingValueApproved = (await page.getByRole('heading', { level: 2 }).innerText()).replace(/\s+/g, "");
 
@@ -25,7 +25,7 @@ test.describe('System Status page tests', () => {
 
     test('System Status table shows up on each system tab', async ({ page }) => {
         for (const system of SYSTEM_MONITOR_DISPLAY_LIST) {
-            await page.getByRole('link', { name: system }).click();
+            await page.getByRole('link', { name: system, exact: true }).click();
 
             const systemStatusTable = page.locator('table.multi-system');
 
@@ -41,7 +41,7 @@ test.describe('System Status page tests', () => {
     
     test('Queue status table shows up on each system tab and shows all system queues', async ({ page }) => {
         for (const system of SYSTEM_MONITOR_DISPLAY_LIST) {
-            await page.getByRole('link', { name: system }).click();
+            await page.getByRole('link', { name: system, exact: true }).click();
         
             const systemQueuesTable = page.locator('article').locator('table');
 

--- a/tests/unauthorized-user/unauthorized-user.spec.js
+++ b/tests/unauthorized-user/unauthorized-user.spec.js
@@ -1,11 +1,19 @@
 import { expect, base } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture'
+import { test } from '../../fixtures/baseFixture';
+import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json';
  
-
+const portalStorageSystems = PORTAL_DATAFILES_STORAGE_SYSTEMS;
 
 test.describe('Unauthorized User Tests', () => {
 
   test('test topnav navigation to public data page', async ({ page, portal, environment, baseURL }) => {
+    let publicDataExists = false;
+    for (const storageSystem of portalStorageSystems) {
+      if (storageSystem.name === 'Public Data') {
+        publicDataExists = true;
+      }
+    }
+    test.skip(publicDataExists === false, 'Public Data not on portal, test skipped');
 
     await page.goto(baseURL);
     await page.getByRole('link', { name: 'Public Data' }).click();
@@ -18,7 +26,7 @@ test.describe('Unauthorized User Tests', () => {
     const url = `${baseURL}/workbench/dashboard`;
     await page.goto(url);
 
-    await page.waitForURL("https://portals.tapis.io/**")
+    await page.waitForURL(/https:\/\/portals(?:\.develop)?\.tapis\.io\/.*$/);
 
     const heading = page.getByRole('heading', {level: 1});
     await expect(heading).toHaveText('Log In');

--- a/utils/pythonHelper.py
+++ b/utils/pythonHelper.py
@@ -29,7 +29,8 @@ with open(f'{settings_folder}/.env.portal') as file:
 data = {
     "PORTAL_DATAFILES_STORAGE_SYSTEMS": custom_portal_settings._PORTAL_DATAFILES_STORAGE_SYSTEMS or [],
     "SYSTEM_MONITOR_DISPLAY_LIST": custom_portal_settings._SYSTEM_MONITOR_DISPLAY_LIST or [],
-    "NGINX_SERVER_NAME": os.getenv('NGINX_SERVER_NAME')
+    "NGINX_SERVER_NAME": os.getenv('NGINX_SERVER_NAME'),
+    "WORKBENCH_SETTINGS":custom_portal_settings._WORKBENCH_SETTINGS or []
 }
 
 with open(output_path, 'w') as json_file: 


### PR DESCRIPTION
Tests should now work with Frontera Portal, and skip tests if the portal has those applications disabled.

To test, run the full suite of tests against the existing CEP configuration.  Then:

1. Replace `settings/custom_portal_settings.py` with the one for [frontera](https://github.com/TACC/Core-Portal-Deployments/blob/main/frontera-portal/camino/prod.settings_custom.py). 
2. Replace the `NGINX_SERVER_NAME` in `.env.portal` with `frontera-portal.tacc.utexas.edu`
3. Run `python3 pythonHelper.py` and make sure that the JSON is created. 
4. Run the full test suite, it should now run against the frontera portal.