### PR TITLE
task/WMAQA-45  Shared Workspace Tests

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -48,7 +48,8 @@ module.exports = defineConfig({
         portal: process.env.PORTAL,
         environment: process.env.ENVIRONMENT,
         baseURL: `https://${NGINX_SERVER_NAME}`
-      }
+      },
+      teardown: 'teardown'
     },
     {
       name: 'default',
@@ -69,6 +70,14 @@ module.exports = defineConfig({
             environment: process.env.ENVIRONMENT,
             baseURL: `https://${NGINX_SERVER_NAME}`
           },
+    },
+    {
+      name: 'teardown',
+      testMatch: 'teardown/*.teardown.js',
+      use: {
+        storageState: 'playwright/.auth/user.json',
+        baseURL: `https://${NGINX_SERVER_NAME}`
+      }
     }
 
     // {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -21,7 +21,7 @@ module.exports = defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 2 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/tests/data-files/data-files-shared-workspace.spec.js
+++ b/tests/data-files/data-files-shared-workspace.spec.js
@@ -1,0 +1,61 @@
+import { expect, base, Page } from '@playwright/test';
+import { test } from '../../fixtures/baseFixture'
+import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json'
+
+const portalStorageSystems = PORTAL_DATAFILES_STORAGE_SYSTEMS
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('Shared Workspaces tests', () => {
+
+    // Skip the tests if portal does not have Shared Workspaces
+    test.skip(!portalStorageSystems.some(system => (system.name === 'Shared Workspaces' && system.scheme === 'projects')))
+
+    test.beforeEach(async ({ page, baseURL }) => {
+        await page.goto(baseURL);
+        await page.locator('#navbarDropdown').click();
+        await page.getByRole('link', { name: 'Dashboard' }).click();
+        await page.getByRole('link', { name: 'Data Files' }).click();
+        await page.getByRole('main').getByRole('link', { name: 'Shared Workspaces' }).click();
+    })
+
+    test('Add Shared Workspace', async ({ page }) => {
+        await page.getByRole('button', { name: '+ Add' }).click();
+        await page.getByRole('menuitem', { name: 'Shared Workspace' }).click();
+
+        await expect(page.locator('.modal-dialog')).toBeVisible();
+        await page.getByRole('textbox').click();
+        await page.getByRole('textbox').fill('Test Shared Workspace');
+        
+        await expect(page.locator('.project-members__cell').nth(0)).toContainText('WMA Test User')
+
+        await page.getByRole('button', { name: 'Add Workspace' }).click();
+
+        await expect(page.locator('.modal-dialog')).not.toBeVisible();
+
+        await expect(page.locator('.listing-placeholder')).toBeVisible();
+
+        await expect(page.getByRole('heading', {level: 3})).toHaveText('Test Shared Workspace')
+    })
+
+    test('Edit Shared Workspace Name and Description', async ({ page }) => {
+        await page.getByRole('link', { name: 'Test Shared Workspace' }).click();
+        await page.getByRole('button', { name: 'Edit Descriptions' }).click();
+
+        await expect(page.locator('.modal-dialog')).toBeVisible();
+
+        await page.getByLabel('title').click();
+        await page.getByLabel('title').fill('');
+        await page.getByLabel('title').fill('Test Shared Workspace Rename');
+
+        await page.getByLabel('description').click();
+        await page.getByLabel('description').fill('Workspace description');
+
+        await page.getByRole('button', { name: 'Update Changes' }).click();
+
+        await expect(page.locator('.modal-dialog')).not.toBeVisible();
+
+        await expect(page.getByRole('heading', {level: 3})).toHaveText('Test Shared Workspace Rename')
+        await expect(page.getByText('Workspace description')).toBeVisible()
+    })
+})

--- a/tests/data-files/data-files-shared-workspace.spec.js
+++ b/tests/data-files/data-files-shared-workspace.spec.js
@@ -1,4 +1,4 @@
-import { expect, base, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { test } from '../../fixtures/baseFixture'
 import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json'
 
@@ -36,6 +36,29 @@ test.describe('Shared Workspaces tests', () => {
         await expect(page.locator('.listing-placeholder')).toBeVisible();
 
         await expect(page.getByRole('heading', {level: 3})).toHaveText('Test Shared Workspace')
+
+        await page.getByRole('main').getByRole('link', { name: 'Shared Workspaces' }).click();
+
+        const table = page.getByRole('table').and(page.locator('.projects-listing'))
+        const rows = await table.locator('tbody').locator('tr').all()
+
+        expect(rows.length).toBe(1);
+
+    })
+
+    test('Shared Workspace Search', async ({ page }) => {
+        const input = page.getByRole('form', { name: 'Workspace Search' }).locator('input')
+        const searchButton = page.getByRole('form', { name: 'Workspace Search' }).getByRole('button', { name: 'Search', exact: true })
+        const table = page.getByRole('table').and(page.locator('.projects-listing'))
+
+        await input.fill('Test Shared Workspace')
+        await searchButton.click();
+        const rows = await table.locator('tbody').locator('tr').all()
+        expect(rows.length).toBe(1);
+
+        await input.fill('random string')
+        await searchButton.click();
+        await expect(table).toContainText("No Shared Workspaces match your search term.")
     })
 
     test('Edit Shared Workspace Name and Description', async ({ page }) => {

--- a/tests/data-files/data-files-shared-workspace.spec.js
+++ b/tests/data-files/data-files-shared-workspace.spec.js
@@ -9,7 +9,7 @@ test.describe.configure({ mode: 'serial' })
 test.describe('Shared Workspaces tests', () => {
 
     // Skip the tests if portal does not have Shared Workspaces
-    test.skip(!portalStorageSystems.some(system => (system.name === 'Shared Workspaces' && system.scheme === 'projects')))
+    test.skip(!portalStorageSystems.some(system => (system.scheme === 'projects')))
 
     test.beforeEach(async ({ page, baseURL }) => {
         await page.goto(baseURL);
@@ -20,6 +20,7 @@ test.describe('Shared Workspaces tests', () => {
     })
 
     test('Add Shared Workspace', async ({ page }) => {
+        test.setTimeout(100000)
         await page.getByRole('button', { name: '+ Add' }).click();
         await page.getByRole('menuitem', { name: 'Shared Workspace' }).click();
 
@@ -31,7 +32,7 @@ test.describe('Shared Workspaces tests', () => {
 
         await page.getByRole('button', { name: 'Add Workspace' }).click();
 
-        await expect(page.locator('.modal-dialog')).not.toBeVisible();
+        await expect(page.locator('.modal-dialog')).not.toBeVisible({timeout: 20000});
 
         await expect(page.locator('.listing-placeholder')).toBeVisible();
 
@@ -42,7 +43,7 @@ test.describe('Shared Workspaces tests', () => {
         const table = page.getByRole('table').and(page.locator('.projects-listing'))
         const rows = await table.locator('tbody').locator('tr').all()
 
-        expect(rows.length).toBe(1);
+        expect(rows.length).toBeGreaterThanOrEqual(1);
 
     })
 

--- a/tests/data-files/data-files-shared-workspace.spec.js
+++ b/tests/data-files/data-files-shared-workspace.spec.js
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import { test } from '../../fixtures/baseFixture'
-import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json'
+import { test } from '../../fixtures/baseFixture';
+import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json';
 
 const portalStorageSystems = PORTAL_DATAFILES_STORAGE_SYSTEMS
 

--- a/tests/teardown/data-files-shared-workspaces.teardown.js
+++ b/tests/teardown/data-files-shared-workspaces.teardown.js
@@ -8,10 +8,12 @@ test('Cleanup shared workspaces', async ({ page, baseURL }) => {
     const tenant = 'https://portals.tapis.io';
     const projectPrefix = PORTAL_PROJECTS_SYSTEM_PREFIX;
 
+    let systems = []
+
     try {
         const accessToken = await getAccessToken(page, username, password, tenant)
 
-        const systems = await getSystems(page, tenant, projectPrefix, accessToken)
+        systems = await getSystems(page, tenant, projectPrefix, accessToken)
     
         for (const system of systems) {
             await deleteSystem(page, system.id, tenant, accessToken)
@@ -29,8 +31,16 @@ test('Cleanup shared workspaces', async ({ page, baseURL }) => {
     await page.getByRole('link', { name: 'Data Files' }).click();
     await page.getByRole('main').getByRole('link', { name: 'Shared Workspaces' }).click();
 
-    await expect(page.locator('.projects-listing')).toContainText("You don't have any Shared Workspaces.")
+    await expect(page.locator('.data-files-nav-link')).toBeVisible();
 
+    const links = await page.locator('.data-files-nav-link').all();
+
+    for (const system of systems) {
+        for (const link of links) {
+            const href = await link.getAttribute('href');
+            expect(href).not.toContain(system.id);
+        }    
+    }
 })
 
 async function getAccessToken(page, username, password, tenant) {

--- a/tests/teardown/data-files-shared-workspaces.teardown.js
+++ b/tests/teardown/data-files-shared-workspaces.teardown.js
@@ -1,0 +1,93 @@
+import { expect } from '@playwright/test';
+import { test } from '../../fixtures/baseFixture'
+import { PORTAL_PROJECTS_SYSTEM_PREFIX } from '../../settings/custom_portal_settings.json'
+
+test('Cleanup shared workspaces', async ({ page, baseURL }) => {
+    const {USERNAME: username, PASSWORD: password} = process.env;
+
+    const tenant = 'https://portals.tapis.io';
+    const projectPrefix = PORTAL_PROJECTS_SYSTEM_PREFIX;
+
+    try {
+        const accessToken = await getAccessToken(page, username, password, tenant)
+
+        const systems = await getSystems(page, tenant, projectPrefix, accessToken)
+    
+        for (const system of systems) {
+            await deleteSystem(page, system.id, tenant, accessToken)
+            console.info(`Teardown: Shared workspace with id ${system.id} deleted`)
+        }
+    } catch (e) {
+        console.error(`An error occured when deleting shared workspaces: ${e.message}`)
+    }
+
+
+    // Ensure there are no shared workspaces left over
+    await page.goto(baseURL);
+    await page.locator('#navbarDropdown').click();
+    await page.getByRole('link', { name: 'Dashboard' }).click();
+    await page.getByRole('link', { name: 'Data Files' }).click();
+    await page.getByRole('main').getByRole('link', { name: 'Shared Workspaces' }).click();
+
+    await expect(page.locator('.projects-listing')).toContainText("You don't have any Shared Workspaces.")
+
+})
+
+async function getAccessToken(page, username, password, tenant) {
+
+    const url = `${tenant}/v3/oauth2/tokens`;
+
+    const data = {
+        username: username, 
+        password: password, 
+        grant_type: 'password'
+    }
+
+    return await page.evaluate(async ({url, data}) => {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data)
+        });
+
+        const jsonResponse = await response.json();
+        return jsonResponse.result.access_token.access_token;
+    }, {url, data});
+
+}
+
+async function getSystems(page, tenant, projectPrefix, accessToken) {
+
+    // get systems that match the prefix of the current portal
+    const url = `${tenant}/v3/systems?search=(id.like.${projectPrefix}*)`;
+
+    return await page.evaluate(async ({url, accessToken}) => {
+        const response = await fetch(url, {
+            headers: {
+                "X-Tapis-Token": accessToken
+            }
+        });
+
+        const jsonResponse = await response.json();
+        return jsonResponse.result;
+
+    }, {url, accessToken})
+}
+
+async function deleteSystem(page, systemId, tenant, accessToken) {
+
+    const url = `${tenant}/v3/systems/${systemId}/delete`;
+
+    return await page.evaluate(async ({url, accessToken}) => {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                "X-Tapis-Token": accessToken
+            } 
+        });
+
+        return await response.json();
+    }, {url, accessToken})
+}

--- a/utils/pythonHelper.py
+++ b/utils/pythonHelper.py
@@ -29,7 +29,8 @@ with open(f'{settings_folder}/.env.portal') as file:
 data = {
     "PORTAL_DATAFILES_STORAGE_SYSTEMS": custom_portal_settings._PORTAL_DATAFILES_STORAGE_SYSTEMS or [],
     "SYSTEM_MONITOR_DISPLAY_LIST": custom_portal_settings._SYSTEM_MONITOR_DISPLAY_LIST or [],
-    "NGINX_SERVER_NAME": os.getenv('NGINX_SERVER_NAME')
+    "NGINX_SERVER_NAME": os.getenv('NGINX_SERVER_NAME'),
+    "PORTAL_PROJECTS_SYSTEM_PREFIX": custom_portal_settings._PORTAL_PROJECTS_SYSTEM_PREFIX or ''
 }
 
 with open(output_path, 'w') as json_file: 


### PR DESCRIPTION
### Overview 

Added tests for shared workspaces. Also added a teardown project that deals with deleting shared workspaces directly using tapis 

### Changes 

- Added shared workspace tests which include adding, editing, and searching shared workspaces 
- Added a teardown project. This project runs at the end after all tests are ran. The shared workspace teardown authenticates with tapis using the test users authentication, gets the users shared workspace systems for the specific portal and deletes those systems 

### Testing 

- Run tests normally using npx playwright test and ensure all tests pass 
- As an addition, also try manually logging onto the portal the tests were ran on and ensure no shared workspaces exist

### Notes 

In the shared workspace teardown there's a new function `page.evaluate` being used when doing external http calls. More details about why this is needed and what it does can be found [here](https://playwright.dev/docs/evaluating)