### PR TITLE
task/WMAQA-54 - Refactor tests for UTRC

### DIFF
--- a/fixtures/fileOperations.ts
+++ b/fixtures/fileOperations.ts
@@ -33,7 +33,6 @@ export class FileOperations {
 
     await page.locator('button:has-text("Upload Selected")').click();
     await page.getByTestId('loading-spinner').last().isHidden();
-    await page.getByRole('dialog').getByRole('button', { name: 'Close' }).click();
   }
 
   async delete(page: Page, ...resourceNameArr: string[]) {

--- a/tests/data-files/data-files-applications.spec.js
+++ b/tests/data-files/data-files-applications.spec.js
@@ -1,5 +1,6 @@
 import { test } from '../../fixtures/baseFixture';
 import { expect, base } from '@playwright/test';
+import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
 
 const apps = ['compress', 'extract']
 
@@ -49,7 +50,7 @@ for (const app of apps) {
                 const toastText = await notificationContent.textContent();
                 const regExp = new RegExp(`${app}.* processing`)
                 await expect(notificationContent).toHaveText(regExp);
-                await expect(notificationContent).not.toBeVisible();
+                await expect(notificationContent).toBeVisible();
         
                 const regex = /(\d{2}:\d{2}:\d{2})/;
                 let jobSubmissionTime = regex.exec(toastText)[1]
@@ -80,18 +81,22 @@ for (const app of apps) {
             })
         
             test('successful job submission and job data', async ({ page }) => {
+                let appName;
+
+                if (app == 'compress'){
+                    appName = WORKBENCH_SETTINGS['compressApp']['id'];
+                }
+                if (app == 'extract'){
+                    appName = WORKBENCH_SETTINGS['extractApp']['id'];
+                }
                         
                 await page.getByRole('link', { name: 'History', exact: true }).click();
-        
-                const regExp = new RegExp(`${app}.*${jobSubmissionTimestamp}`)
-                const row =  page.locator("tr", { has: page.getByText(regExp)})
-        
-                const statusRegExp = new RegExp(statuses.join('|'))
-                await expect(row.locator('td').nth(2), 'Does not have a valid status').toHaveText(statusRegExp, { ignoreCase: true })
-        
-                // Open job details modal and verify job info
+                const regExp = new RegExp(`${appName}.*${jobSubmissionTimestamp}`);
+                const row =  page.locator("tr", { hasText: regExp});
+                const statusRegExp = new RegExp(statuses.join('|'));
+                await expect(row, 'Does not have a valid status').toHaveText(statusRegExp, { ignoreCase: true })
                 await row.getByRole('link', { name: 'View Details', exact: true }).click();
-                await expect(page.locator('dd:below(:text("App ID"))').first()).toHaveText(app);
+                await expect(page.locator('dd:below(:text("App ID"))').first()).toHaveText(appName);
     
                 if (app === 'compress') {
                     await expect(page.locator('dd:below(:text("Archive File Name"))').first()).toHaveText('testCompress');


### PR DESCRIPTION
### Overview 

Refactored tests to work with UTRC.

### Changes 

- Removed steps to close modals. This is a change in all portals.
- Removed assertion that notifications are not visible for compress and extract. This is a change in all portals.
- Compress and extract app names are now brought in from workbench settings.
- The job history locator is now more accurate.

### Testing 

- Get custom settings and nginx settings for UTRC from the deployment repo, and run the pythonHelper script.
- Run tests normally using `npx playwright test` and ensure all tests pass.

### Notes 

Some of these tests will fail, because they are addressed by other PRs waiting for approval.