### PR TITLE
WMAQA-53: refactor for PTDATAX

### DIFF
--- a/tests/dashboard/dashboard-onboarding-admin.spec.js
+++ b/tests/dashboard/dashboard-onboarding-admin.spec.js
@@ -1,18 +1,21 @@
 import { expect, base } from '@playwright/test';
 import { test } from '../../fixtures/baseFixture'
- 
+
 
 test.describe('Onboarding Admin page tests', () => {
-  
+
   test.beforeEach(async ({ page, portal, environment, baseURL }) => {
     await page.goto(baseURL);
     await page.locator('#navbarDropdown').click();
+    if (expect(page.getByRole('link', { name: 'Onboarding Admin' }).isDisabled)) {
+      test.skip('user does not have onboarding admin');
+    }
     await page.getByRole('link', { name: 'Onboarding Admin' }).click();
   })
 
-  test('test navigation to correct page', async ({ page }) => {    
-      const heading = page.getByRole('heading', {level: 5});
-      await expect(heading).toHaveText('Administrator Controls');
+  test('test navigation to correct page', async ({ page }) => {
+    const heading = page.getByRole('heading', { level: 5 });
+    await expect(heading).toHaveText('Administrator Controls');
   });
 
   test('test table is populated', async ({ page }) => {
@@ -30,14 +33,14 @@ test.describe('Onboarding Admin page tests', () => {
 
     const firstPageElement = await firstPageRows[0].innerText()
     expect(page.getByRole('button', { name: '< Previous' })).toBeDisabled()
-    
+
     await page.getByRole('button', { name: 'Next >' }).click();
     await expect(table.locator('tbody')).toBeVisible()
     const secondPageRows = await table.locator('tbody').locator('tr').all()
     const secondPageElement = await secondPageRows[0].innerText()
     expect(secondPageElement).not.toEqual(firstPageElement)
-   
-    await page.getByRole('button', { name: '< Previous' }).click(); 
+
+    await page.getByRole('button', { name: '< Previous' }).click();
     await expect(table.locator('tbody')).toBeVisible()
     const newFirstPageRows = await table.locator('tbody').locator('tr').all()
     const newFirstPageElement = await newFirstPageRows[0].innerText()
@@ -89,15 +92,15 @@ test.describe('Onboarding Admin page tests', () => {
 
       await viewLogsButton.click();
       await expect(page.locator('.modal-dialog')).toBeVisible();
-      const heading = page.locator('.modal-dialog').getByRole('heading', {level: 6});
+      const heading = page.locator('.modal-dialog').getByRole('heading', { level: 6 });
 
       if (stepType === 'Allocations') {
         await expect(heading).toHaveText(`${name} - Allocations`)
       }
-       else {
+      else {
         await expect(heading).toHaveText(`${name} - System Access`)
       }
-      
+
       await page.getByRole('button', { name: 'Close' }).click();
     }
   });

--- a/tests/history/history.spec.js
+++ b/tests/history/history.spec.js
@@ -1,9 +1,9 @@
 import { test } from '../../fixtures/baseFixture'
 import { expect, base } from '@playwright/test';
 import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
- 
+
 const jobsv2Title = WORKBENCH_SETTINGS['jobsv2Title'];
- 
+
 
 
 test.describe('History Page Navigation Tests', () => {
@@ -31,6 +31,9 @@ test.describe('History Page Navigation Tests', () => {
     })
 
     test('Jobv2 tab is displayed and redirects correctly', async ({ page, portal, environment, baseURL }) => {
+        if (jobsv2Title === null) {
+            test.skip("this portal does not have a jobsv2Title");
+        }
         await expect(page.getByRole('link', { name: jobsv2Title })).toBeVisible();
 
         await page.getByRole('link', { name: jobsv2Title }).click();


### PR DESCRIPTION
Changes Made:
- Update to the jobsv2Title call for the job history test. PT specific but could be something other portals might not have
- Update to the onboarding admin test to check if the account being tested has access. This will technically affect all portals, but only if our test user does not have onboarding admin.  Potentially will need updating if we swap to having multiple users where one has admin and one does not.

Also note that the onboarding file was updated by Juan in his PR, there shouldn't be conflicts but who knows if git might complain.