### PR TITLE
task/WMAQA-82 - Application List Test

### DIFF
--- a/tests/applications/applications.spec.js
+++ b/tests/applications/applications.spec.js
@@ -15,3 +15,42 @@ test('test navigation to application page', async ({ page, portal, environment, 
   await expect(heading).toHaveText('Applications');
   
 });
+
+test('test app tray application visibility', async ({ page, portal, environment, baseURL }) => {
+  test.skip(hideApps === true, 'Apps hidden on portal, test skipped');
+  
+  const appTray = await getAppTray(page, baseURL);
+
+  await page.goto(baseURL);
+  await page.locator('#navbarDropdown').click();
+  await page.getByRole('link', { name: 'Dashboard' }).click();
+  await page.getByRole('link', { name: 'Applications', exact: true }).click();
+
+  for (const tab of appTray) {
+    const tabName = tab.title;
+    await page.locator('#appBrowser-wrapper')
+    .getByRole('listitem')
+    .getByText(`${tabName} [${tab.apps.length}]`).click();
+
+    for (const app of tab.apps) {
+      const appName = app.label;
+      const appLink = page.getByRole('link', { name: appName, exact: true });
+      await expect(appLink).toBeVisible();
+    }
+
+  };
+})
+
+async function getAppTray(page, baseURL) {
+    const url = `${baseURL}/api/workspace/tray`;
+
+    const cookies = await page.context().cookies()
+
+    const headers = {
+        'Cookie': cookies.map(cookie => `${cookie.name}=${cookie.value}`).join('; ')
+    };
+
+    const response = await page.request.get(url, {headers: headers});
+    const jsonResponse = await response.json();
+    return jsonResponse.tabs;
+}


### PR DESCRIPTION
[WMAQA-82](https://tacc-main.atlassian.net/browse/WMAQA-82)

This test retrieves a list of applications from the backend that should be shown on the portal and then validates whether or not each application is displayed in the portal 