### PR TITLE
task/WMAQA-90 - Create Slack Notifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,20 +62,13 @@ pipeline {
    }
    post {
       always {
-         publishHTML([
-            allowMissing: true, 
-            alwaysLinkToLastBuild: true, 
-            keepAll: true, 
-            reportDir: 'playwright-report', 
-            reportFiles: 'index.html', 
-            reportName: 'Playwright Test Report', 
-            reportTitles: ''
-         ])
-         slackUploadFile(
-            channel: 'wma-ops', 
-            filePath: 'playwright-report/index.html',
-            initialComment: 'Results of nightly E2E run', 
-        ) 
+         junit(
+            allowEmptyResults: true,
+            testResults: 'playwright-report/results.xml'
+         )
+         slackSend(
+            channel: "wma-ops", 
+            message: "Ran E2E tests")
          cleanWs()
       }
    }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
          )
          slackSend(
             channel: "wma-ops", 
-            message: "Ran E2E tests")
+            message: "Ran E2E tests: https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_E2E_Tests/${currentBuild.number}/testReport/")
          cleanWs()
       }
    }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
             testResults: 'playwright-report/results.xml'
          )
          slackSend(
-            channel: "wma-ops", 
+            channel: "wma-e2e-slack-notifications", 
             message: "Ran E2E tests: https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_E2E_Tests/${currentBuild.number}/testReport/")
          cleanWs()
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,10 +71,11 @@ pipeline {
             reportName: 'Playwright Test Report', 
             reportTitles: ''
          ])
-         junit(
-            allowEmptyResults: true,
-            testResults: 'playwright-report/results.xml'
-         )
+         slackUploadFile(
+            channel: 'wma-ops', 
+            filePath: 'playwright-report/index.html',
+            initialComment: 'Results of nightly E2E run', 
+        ) 
          cleanWs()
       }
    }


### PR DESCRIPTION
## Overview

This is the "simple" version of our slack notifications. It just tells us that our tests ran, and links to the XML report in Jenkins with the information that we need. Will create an additonal JIRA to message a more detailed HTML report to Slack, so that i people will not need to log into Jenkins.

## Related

* [WMAQA-90](https://tacc-main.atlassian.net/browse/WMAQA-90) 

## Changes
- Removes HTML report, as Jenkins is not able to display these without significant changes to security infrastructure
- Will send a message to slack and link to run


## Testing

Impossible without merging into main and pushing, sorry. But, a previous run here: https://tacc-team.slack.com/archives/C9ML70PGV/p1747429549412849

Here is how I tested, but it isn't something I would recommend. If you're not careful, you can lose code:
1. Merged branch into main, but kept original feature branch. Pushed branch to origin.
2. Ran tests against a portal I knew would fail immediately (one of the ones that is not accessible in PROD)
3. Verified that message had been sent to slack.
4. Used `git reset --hard` to remove my changes. Compared to the remote main branch. Verified that none of the changes that were originally in main were lost. Force pushed main branch to origin again.

## UI
