### PR TITLE
task/WMAQA-93 - Add MFA Support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,9 +53,12 @@ pipeline {
 
       stage('e2e-tests') {
          steps {
-            withCredentials([usernamePassword(credentialsId: 'portal_tests_user', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+            withCredentials([
+               usernamePassword(credentialsId: 'portal_tests_user', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD'),
+               string(credentialsId: 'PORTALS_TEST_USER_MFA_SECRET', variable: 'MFA_SECRET')
+            ]) {
                sh 'npx playwright test --list'
-               sh 'USERNAME=$USERNAME PASSWORD=$PASSWORD npx playwright test'
+               sh 'USERNAME=$USERNAME PASSWORD=$PASSWORD MFA_SECRET=$MFA_SECRET npx playwright test'
             }
          }
       }

--- a/fixtures/baseFixture.js
+++ b/fixtures/baseFixture.js
@@ -1,7 +1,9 @@
 import { test as base } from '@playwright/test'
+import dotenv from 'dotenv'
 
 export const test = base.extend({
     portal: ['cep', {option: true}],
     environment: ['prod', {option: true}],
-    baseURL: ['https://cep.tacc.utexas.edu', {option: true}]
+    baseURL: ['https://cep.tacc.utexas.edu', {option: true}],
+    mfaSecret: [process.env.MFA_SECRET, {option: true}]
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,22 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dotenv": "^16.0.3"
+        "dotenv": "^16.0.3",
+        "otpauth": "^9.3.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.46.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@playwright/test": {
@@ -52,6 +64,17 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/otpauth": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.3.3.tgz",
+      "integrity": "sha512-4w8X5BqWsnt/w0knrr94Eho+gY0m6Wr2J1lfi2J0GnJkF/iauqZ2X3QA4wou7efhzT590jcZBRW8Y9EdQPGFRw==",
+      "dependencies": {
+        "@noble/hashes": "1.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/hectorm/otpauth?sponsor=1"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.46.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
@@ -84,6 +107,11 @@
     }
   },
   "dependencies": {
+    "@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
+    },
     "@playwright/test": {
       "version": "1.46.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.1.tgz",
@@ -104,6 +132,14 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "otpauth": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.3.3.tgz",
+      "integrity": "sha512-4w8X5BqWsnt/w0knrr94Eho+gY0m6Wr2J1lfi2J0GnJkF/iauqZ2X3QA4wou7efhzT590jcZBRW8Y9EdQPGFRw==",
+      "requires": {
+        "@noble/hashes": "1.5.0"
+      }
     },
     "playwright": {
       "version": "1.46.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@playwright/test": "^1.46.1"
   },
   "dependencies": {
-    "dotenv": "^16.0.3"
+    "dotenv": "^16.0.3",
+    "otpauth": "^9.3.3"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -48,7 +48,8 @@ module.exports = defineConfig({
       use: {
         portal: process.env.PORTAL,
         environment: process.env.ENVIRONMENT,
-        baseURL: `https://${NGINX_SERVER_NAME}`
+        baseURL: `https://${NGINX_SERVER_NAME}`,
+        mfaSecret: process.env.MFA_SECRET
       },
       teardown: 'teardown'
     },

--- a/settings/.env.secret_example
+++ b/settings/.env.secret_example
@@ -1,2 +1,3 @@
 USERNAME='username'
 PASSWORD='password'
+MFA_SECRET='mfa_secret'


### PR DESCRIPTION
Adds MFA support. Generates an MFA token using the OTPAuth library. 

This updates the JenkinsFile as well. A new credential for the MFA secret has been added to Jenkins as well that the JenkinsFile pulls in when running the test suite

Testing Steps:
- Do an `npm install` to install the new packages
- Change configuration files to use `dev.cep` (only portal with MFA so far)
- Update local `.env.secret` file with `MFA_SECRET` credential (secret can be found in `WMA E2E Test User` stache entry)
- Run test suite and ensure auth setup passes and tests run