### PR TITLE
task/WMAQA-95 - Add Details to Slack Notification

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,9 +76,9 @@ pipeline {
             def statusText = buildStatus == 'SUCCESS' ? 'PASSED' : 'FAILED'
             
             // Get test statistics from Jenkins test results
-            def passedTests = currentBuild.rawBuild.getAction(hudson.tasks.junit.TestResultAction.class)?.passCount ?: 0
-            def failedTests = currentBuild.rawBuild.getAction(hudson.tasks.junit.TestResultAction.class)?.failCount ?: 0
-            def skippedTests = currentBuild.rawBuild.getAction(hudson.tasks.junit.TestResultAction.class)?.skipCount ?: 0
+            def passedTests = currentBuild.getTestResultSummary()?.passCount ?: 0
+            def failedTests = currentBuild.getTestResultSummary()?.failCount ?: 0
+            def skippedTests = currentBuild.getTestResultSummary()?.skipCount ?: 0
             
             def message = """
                   ${statusEmoji} *Core Portal E2E Tests - ${statusText}*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,17 +74,13 @@ pipeline {
             def buildStatus = currentBuild.result ?: 'SUCCESS'
             def statusEmoji = buildStatus == 'SUCCESS' ? ':white_check_mark:' : ':x:'
             def statusText = buildStatus == 'SUCCESS' ? 'PASSED' : 'FAILED'
-            
-            // Get test statistics from Jenkins test results
-            def passedTests = currentBuild.getTestResultSummary()?.passCount ?: 0
-            def failedTests = currentBuild.getTestResultSummary()?.failCount ?: 0
-            def skippedTests = currentBuild.getTestResultSummary()?.skipCount ?: 0
-            
+            def summary = junit testResults: 'playwright-report/results.xml'
+
             def message = """
                   ${statusEmoji} *Core Portal E2E Tests - ${statusText}*
                   - *Portal:* ${params.Portal}
                   - *Environment:* ${params.Environment}
-                  - *Tests:* ${passedTests} passed, ${failedTests} failed, ${skippedTests} skipped
+                  - *Tests:* ${summary.totalCount}, Failures: ${summary.failCount}, Skipped: ${summary.skipCount}, Passed: ${summary.passCount}
 
                   <https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_E2E_Tests/${currentBuild.number}/testReport/|View Test Report>
             """.stripIndent()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
    }
    post {
       always {
-         junit(
+         def testResults = junit(
             allowEmptyResults: true,
             testResults: 'playwright-report/results.xml'
          )
@@ -74,13 +74,12 @@ pipeline {
             def buildStatus = currentBuild.result ?: 'SUCCESS'
             def statusEmoji = buildStatus == 'SUCCESS' ? ':white_check_mark:' : ':x:'
             def statusText = buildStatus == 'SUCCESS' ? 'PASSED' : 'FAILED'
-            def summary = junit testResults: 'playwright-report/results.xml'
 
             def message = """
                   ${statusEmoji} *Core Portal E2E Tests - ${statusText}*
                   - *Portal:* ${params.Portal}
                   - *Environment:* ${params.Environment}
-                  - *Tests:* ${summary.totalCount}, Failures: ${summary.failCount}, Skipped: ${summary.skipCount}, Passed: ${summary.passCount}
+                  - *Tests:* Total: ${testResults.totalCount}, Passed: ${testResults.passCount}, Failed: ${testResults.failCount}, Skipped: ${testResults.skipCount}
 
                   <https://jenkins.portals.tacc.utexas.edu/job/Core_Portal_E2E_Tests/${currentBuild.number}/testReport/|View Test Report>
             """.stripIndent()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,12 +65,12 @@ pipeline {
    }
    post {
       always {
-         def testResults = junit(
-            allowEmptyResults: true,
-            testResults: 'playwright-report/results.xml'
-         )
-         
          script {
+            def testResults = junit(
+               allowEmptyResults: true,
+               testResults: 'playwright-report/results.xml'
+            )
+            
             def buildStatus = currentBuild.result ?: 'SUCCESS'
             def statusEmoji = buildStatus == 'SUCCESS' ? ':white_check_mark:' : ':x:'
             def statusText = buildStatus == 'SUCCESS' ? 'PASSED' : 'FAILED'


### PR DESCRIPTION
Adds details to slack notifications including portal name, environment, test result and number of tests passed, failed, and skipped