### PR TITLE
task/wmaqa 104: refactor for cipp

### DIFF
--- a/tests/history/history.spec.js
+++ b/tests/history/history.spec.js
@@ -2,7 +2,7 @@ import { test } from '../../fixtures/baseFixture'
 import { expect, base } from '@playwright/test';
 import { WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
 
-const jobsv2Title = WORKBENCH_SETTINGS['jobsv2Title'];
+const jobsv2Title = WORKBENCH_SETTINGS['jobsv2Title'] || null;
 
 
 

--- a/tests/publicData/publicData.spec.js
+++ b/tests/publicData/publicData.spec.js
@@ -10,21 +10,25 @@ for (const entry of PORTAL_DATAFILES_STORAGE_SYSTEMS) {
   }
 }
 
+let topNavPortals = ['CEP', 'DRP', '3dem'];
+
 test.describe('Public Data Tests', async () => {
-  
+
   test.skip(publicDataEntry === false, 'Public Data not on portal, test skipped');
 
   test.beforeEach(async ({ page, portal, environment, baseURL }) => {
     await page.goto(baseURL);
   })
-    
-  test('test topnav navigation to public data page', async ({ page, portal, environment, baseURL }) => {
 
-      await page.getByRole('link', { name: 'Public Data' }).click();
-      
-      const heading = page.getByRole('heading', {level: 2});
-      await expect(heading.locator('.system-name')).toHaveText('Public Data');
-    });
+  test('test topnav navigation to public data page', async ({ page, portal, environment, baseURL }) => {
+    if (!topNavPortals.includes(portal)) {
+      test.skip();
+    }
+
+    await page.getByRole('link', { name: 'Public Data' }).click();
+    const heading = page.getByRole('heading', { level: 2 });
+    await expect(heading.locator('.system-name')).toHaveText('Public Data');
+  });
 })
 
 

--- a/tests/publicData/publicData.spec.js
+++ b/tests/publicData/publicData.spec.js
@@ -10,7 +10,7 @@ for (const entry of PORTAL_DATAFILES_STORAGE_SYSTEMS) {
   }
 }
 
-let topNavPortals = ['CEP', 'DRP', '3dem'];
+let topNavPortals = ['DRP', '3dem'];
 
 test.describe('Public Data Tests', async () => {
 

--- a/tests/unauthorized-user/unauthorized-user.spec.js
+++ b/tests/unauthorized-user/unauthorized-user.spec.js
@@ -1,7 +1,7 @@
 import { expect, base } from '@playwright/test';
 import { test } from '../../fixtures/baseFixture';
 import { PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json';
- 
+
 const portalStorageSystems = PORTAL_DATAFILES_STORAGE_SYSTEMS;
 
 test.describe('Unauthorized User Tests', () => {
@@ -15,10 +15,15 @@ test.describe('Unauthorized User Tests', () => {
     }
     test.skip(publicDataExists === false, 'Public Data not on portal, test skipped');
 
+    let topNavPortals = ['CEP', 'DRP', '3dem'];
+    if (!topNavPortals.includes(portal)) {
+      test.skip();
+    }
+
     await page.goto(baseURL);
     await page.getByRole('link', { name: 'Public Data' }).click();
 
-    const heading = page.getByRole('heading', {level: 2});
+    const heading = page.getByRole('heading', { level: 2 });
     await expect(heading.locator('.system-name')).toHaveText('Public Data');
   });
 
@@ -28,7 +33,7 @@ test.describe('Unauthorized User Tests', () => {
 
     await page.waitForURL(/https:\/\/portals(?:\.develop)?\.tapis\.io\/.*$/);
 
-    const heading = page.getByRole('heading', {level: 1});
+    const heading = page.getByRole('heading', { level: 1 });
     await expect(heading).toHaveText('Log In');
   })
 })

--- a/tests/unauthorized-user/unauthorized-user.spec.js
+++ b/tests/unauthorized-user/unauthorized-user.spec.js
@@ -15,7 +15,7 @@ test.describe('Unauthorized User Tests', () => {
     }
     test.skip(publicDataExists === false, 'Public Data not on portal, test skipped');
 
-    let topNavPortals = ['CEP', 'DRP', '3dem'];
+    let topNavPortals = ['DRP', '3dem'];
     if (!topNavPortals.includes(portal)) {
       test.skip();
     }


### PR DESCRIPTION
fixing a couple tests to work for cipp
there are some known test failures related to cipp being on a separate tapis tenant that will be handled by another task