### PR TITLE
task/WMAQA-99 - Add support for dynamic tenant retrieval

### DIFF
--- a/fixtures/baseFixture.js
+++ b/fixtures/baseFixture.js
@@ -5,5 +5,6 @@ export const test = base.extend({
     portal: ['cep', {option: true}],
     environment: ['prod', {option: true}],
     baseURL: ['https://cep.tacc.utexas.edu', {option: true}],
-    mfaSecret: [process.env.MFA_SECRET, {option: true}]
+    mfaSecret: [process.env.MFA_SECRET, {option: true}],
+    tapisTenantBaseUrl: [process.env.TAPIS_TENANT_BASEURL || '', {option: true}]
 })

--- a/tests/data-files/data-files-my-data-operations.spec.js
+++ b/tests/data-files/data-files-my-data-operations.spec.js
@@ -160,7 +160,7 @@ test.describe('Data Files My Data Work Operations tests', () => {
         expect(copied_file).toBeUndefined;
     })
 
-    test('Link File', async ({ page, portal, fileOperations }) => {
+    test('Link File', async ({ page, portal, fileOperations, tapisTenantBaseUrl }) => {
         test.skip(makeLink === false, 'Link File hidden on portal, test skipped');
 
         //click into the data files area
@@ -186,7 +186,7 @@ test.describe('Data Files My Data Work Operations tests', () => {
         await expect(page.getByTestId('loading-spinner')).not.toBeVisible();
         await page.getByRole('button', { name: 'Generate Link' }).click();
         const link = await page.getByRole('textbox').getAttribute('value');
-        expect(link).toContain("https://portals.tapis.io/v3/files/postits/redeem/");
+        expect(link).toContain(`${tapisTenantBaseUrl}/v3/files/postits/redeem/`);
         //clipboard check for copy button
         await page.getByRole('dialog').getByRole('button', { name: 'Copy' }).click();
         let clipboardText = await page.evaluate("navigator.clipboard.readText()");
@@ -196,7 +196,7 @@ test.describe('Data Files My Data Work Operations tests', () => {
         await page.getByRole('button', { name: 'Confirm' }).click();
         const link2 = await page.getByRole('textbox').getAttribute('value');
         //TODO: refactor to work with other tapis tenants
-        expect(link2).toContain("https://portals.tapis.io/v3/files/postits/redeem/");
+        expect(link2).toContain(`${tapisTenantBaseUrl}/v3/files/postits/redeem/`);
         //"delete" check
         await page.getByRole('button', { name: 'Delete' }).click();
         await page.getByRole('button', { name: 'Confirm' }).click();

--- a/tests/setup/auth.setup.js
+++ b/tests/setup/auth.setup.js
@@ -17,6 +17,12 @@ setup('authenticate', async ({ page, portal, environment, baseURL, mfaSecret }) 
   await page.waitForURL('**/*');
   const redirectUrl = page.url();
   
+  // Extract base URL (protocol + hostname) and set as environment variable
+  const url = new URL(redirectUrl);
+  const tapisTenantBaseUrl = `${url.protocol}//${url.hostname}`;
+  
+  process.env.TAPIS_TENANT_BASEURL = tapisTenantBaseUrl;
+    
   if (redirectUrl.includes('/oauth2/mfa')) {
     // MFA flow
     let totp = new OTPAuth.TOTP({

--- a/tests/teardown/data-files-shared-workspaces.teardown.js
+++ b/tests/teardown/data-files-shared-workspaces.teardown.js
@@ -2,9 +2,9 @@ import { expect } from '@playwright/test';
 import { test } from '../../fixtures/baseFixture';
 import { PORTAL_PROJECTS_SYSTEM_PREFIX } from '../../settings/custom_portal_settings.json'
 
-test('Cleanup shared workspaces', async ({ page, baseURL }) => {
+test('Cleanup shared workspaces', async ({ page, baseURL, tapisTenantBaseUrl }) => {
 
-    const tenant = 'https://portals.tapis.io';
+    const tenant = tapisTenantBaseUrl;
     const projectPrefix = PORTAL_PROJECTS_SYSTEM_PREFIX;
 
     let systems = []


### PR DESCRIPTION
Removes hardcoded tenant url and dynamically retrieves the tenant url for a portal. 

The url is retrieved during the authentication step and stored as an environment variable to use in other tests