### PR TITLE
task/WMAQA-124 - Updating playwright to v 1.59.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "otpauth": "^9.3.3"
       },
       "devDependencies": {
-        "@playwright/test": "^1.46.1"
+        "@playwright/test": "^1.59.1"
       }
     },
     "node_modules/@noble/hashes": {
@@ -28,12 +28,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.1.tgz",
-      "integrity": "sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.46.1"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -76,12 +76,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
-      "integrity": "sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.46.1"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -94,9 +94,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz",
-      "integrity": "sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -113,12 +113,12 @@
       "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
     },
     "@playwright/test": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.1.tgz",
-      "integrity": "sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "requires": {
-        "playwright": "1.46.1"
+        "playwright": "1.59.1"
       }
     },
     "dotenv": {
@@ -142,19 +142,19 @@
       }
     },
     "playwright": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
-      "integrity": "sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.46.1"
+        "playwright-core": "1.59.1"
       }
     },
     "playwright-core": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz",
-      "integrity": "sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/TACC/Core-Portal-E2E#readme",
   "devDependencies": {
-    "@playwright/test": "^1.46.1"
+    "@playwright/test": "^1.59.1"
   },
   "dependencies": {
     "dotenv": "^16.0.3",


### PR DESCRIPTION
Run `npx playwright install --with-deps` and then `npx playwright --version` to verify that the version has been updated to `1.59.1`. 

Run `npx playwright test` to verify tests still work and no regressions introduced. 

There are new features introduced, including improved UI tool, [a testStepInfo object](https://playwright.dev/docs/api/class-teststepinfo), [improved timeouts](https://playwright.dev/docs/api/class-test#test-step-option-timeout), and [LLM agents.](https://playwright.dev/docs/test-agents).