### PR TITLE
task/WMAQA-122 - Custom Portal Testing Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 3. Run the following command from root of the project: `python3 utils/pythonHelper.py` and ensure a file named `custom_portal_settings.json` gets created in the settings folder with some portal data
 4. The test suite can be run using one of the following commands:
 	- Full test suite (runs all the tests available):
-		-  `npx playwright test --project=default --project=unauthorized`
+		-  `npx playwright test --project=default --project=portal-custom --project=unauthorized`
 	- Limited test suite (skips application and datafile tests):
-		- `npx playwright test --project=limited --project=unauthorized`
+		- `npx playwright test --project=limited --project=portal-custom --project=unauthorized`
 
 # To run other CEP portals:
 1. Repeat Steps 2-3 from above for the portal you want to test, replacing or renaming the previous files.

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 const { defineConfig, devices } = require('@playwright/test');
 import dotenv from 'dotenv'
-import { NGINX_SERVER_NAME } from './settings/custom_portal_settings.json'
+import { NGINX_SERVER_NAME, PORTAL_NAME } from './settings/custom_portal_settings.json'
 
 /**
  * Read environment variables from file.
@@ -10,6 +10,9 @@ import { NGINX_SERVER_NAME } from './settings/custom_portal_settings.json'
 
 dotenv.config({path: 'settings/.env.default'})
 dotenv.config({path: 'settings/.env.secret'})
+
+const portalName = ( PORTAL_NAME || '').toLowerCase().trim();
+const portalCustomTestMatch = [`custom/${portalName}/**/*.spec.js`];
 
 /**
  * @see https://playwright.dev/docs/test-configuration
@@ -97,6 +100,19 @@ module.exports = defineConfig({
             environment: process.env.ENVIRONMENT,
             baseURL: `https://${NGINX_SERVER_NAME}`
           },
+    },
+    {
+      name: 'portal-custom',
+      testMatch: portalCustomTestMatch,
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+        portal: process.env.PORTAL,
+        environment: process.env.ENVIRONMENT,
+        baseURL: `https://${NGINX_SERVER_NAME}`,
+        portalName: portalName
+      },
+      dependencies: ['setup'],
     },
     {
       name: 'teardown',

--- a/tests/custom/ami/test.spec.js
+++ b/tests/custom/ami/test.spec.js
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('AMI custom portal smoke test', async () => {
+  expect(true).toBe(true);
+});

--- a/tests/custom/cep/test.spec.js
+++ b/tests/custom/cep/test.spec.js
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('CEP custom portal smoke test', async () => {
+  expect(true).toBe(true);
+});

--- a/utils/pythonHelper.py
+++ b/utils/pythonHelper.py
@@ -32,7 +32,8 @@ data = {
     "NGINX_SERVER_NAME": os.getenv('NGINX_SERVER_NAME'),
     "WORKBENCH_SETTINGS":custom_portal_settings._WORKBENCH_SETTINGS or [],
     "PORTAL_PROJECTS_SYSTEM_PREFIX": custom_portal_settings._PORTAL_PROJECTS_SYSTEM_PREFIX or '',
-    "PORTAL_USER_ACCOUNT_SETUP_STEPS": custom_portal_settings._PORTAL_USER_ACCOUNT_SETUP_STEPS or ''
+    "PORTAL_USER_ACCOUNT_SETUP_STEPS": custom_portal_settings._PORTAL_USER_ACCOUNT_SETUP_STEPS or '',
+    "PORTAL_NAME": custom_portal_settings._PORTAL_NAMESPACE or ''
 }
 
 with open(output_path, 'w') as json_file: 


### PR DESCRIPTION
Adds support for custom portal testing. Custom portal folders can be created under `tests/custom/{portal_name}`. The custom tests can be run by adding `--project=portal-custom` to the runtime command. 

Testing Steps: 
1 - Custom smoke tests have been added for AMI and CEP
2 - Make sure to update the custom config files (use either AMI or CEP) and run `python3 utils/pythonHelper.py`
3 - Run test using the command `npx playwright test --project=portal-custom`
4 - Make sure the custom test for the portal was run 

Once this gets merged in, we can add `--project=portal-custom` to our current command in jenkins and everything should work. 