### PR TITLE
task/WMAQA-134 - Skip Logic for Shared Workspace Tests

### DIFF
--- a/tests/data-files/data-files-shared-workspace-operations.spec.js
+++ b/tests/data-files/data-files-shared-workspace-operations.spec.js
@@ -11,8 +11,9 @@ const hideDataFiles = WORKBENCH_SETTINGS['hideDataFiles'];
 test.describe('Shared Workspaces tests', () => {
 
     // Skip the tests if portal does not have Shared Workspaces
-    test.skip(!portalStorageSystems.some(system => (system.scheme === 'projects')));
-        test.skip(hideDataFiles === true, 'Data Files hidden on portal, tests skipped');
+    test.skip(!portalStorageSystems.some(system => (system.scheme === 'projects')), 
+    'Portal does not have shared workspaces, tests skipped');
+    test.skip(hideDataFiles === true, 'Data Files hidden on portal, tests skipped');
 
     test.beforeEach(async ({ page, baseURL }) => {
         await page.goto(baseURL);

--- a/tests/teardown/data-files-shared-workspaces.teardown.js
+++ b/tests/teardown/data-files-shared-workspaces.teardown.js
@@ -1,11 +1,16 @@
 import { expect } from '@playwright/test';
 import { test } from '../../fixtures/baseFixture';
-import { PORTAL_PROJECTS_SYSTEM_PREFIX, WORKBENCH_SETTINGS } from '../../settings/custom_portal_settings.json';
+import { PORTAL_PROJECTS_SYSTEM_PREFIX, WORKBENCH_SETTINGS, PORTAL_DATAFILES_STORAGE_SYSTEMS } from '../../settings/custom_portal_settings.json';
 
 const hideDataFiles = WORKBENCH_SETTINGS['hideDataFiles'];
+const portalStorageSystems = PORTAL_DATAFILES_STORAGE_SYSTEMS
 
 test('Cleanup shared workspaces', async ({ page, baseURL, tapisTenantBaseUrl }) => {
-    test.skip(hideDataFiles === true, 'Data Files hidden on portal, tests skipped');
+
+    test.skip(!portalStorageSystems.some(system => (system.scheme === 'projects')), 
+    'Portal does not have shared workspaces, tests skipped');
+
+    test.skip(hideDataFiles === true || !hasSharedWorkspaces, 'Data Files hidden on portal, tests skipped');
 
     const tenant = tapisTenantBaseUrl;
     const projectPrefix = PORTAL_PROJECTS_SYSTEM_PREFIX;


### PR DESCRIPTION
This will allow Shared Workspace tests to be skipped when they are not present. The logic already existed previously for the Shared Workspace operation tests. This is adding that logic to the teardown as well. 