### PR TITLE
hotfix: removing an unused variable from teardown method

### DIFF
--- a/tests/teardown/data-files-shared-workspaces.teardown.js
+++ b/tests/teardown/data-files-shared-workspaces.teardown.js
@@ -7,10 +7,10 @@ const portalStorageSystems = PORTAL_DATAFILES_STORAGE_SYSTEMS
 
 test('Cleanup shared workspaces', async ({ page, baseURL, tapisTenantBaseUrl }) => {
 
-    test.skip(!portalStorageSystems.some(system => (system.scheme === 'projects')), 
+    test.skip(!portalStorageSystems.some(system => (system.scheme === 'projects')),
     'Portal does not have shared workspaces, tests skipped');
 
-    test.skip(hideDataFiles === true || !hasSharedWorkspaces, 'Data Files hidden on portal, tests skipped');
+    test.skip(hideDataFiles === true, 'Data Files hidden on portal, tests skipped');
 
     const tenant = tapisTenantBaseUrl;
     const projectPrefix = PORTAL_PROJECTS_SYSTEM_PREFIX;


### PR DESCRIPTION
hasSharedWorkspaces doesn't seem to be a variable within any Core Portal or E2E testing, so I'm removing it.

To test this, run the tests that involve shared systems. To make sure it skips, set hideDataFiles to true.